### PR TITLE
Feat/implement vbase for offers map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Implement VBase for the `offersMap` used in the resolvers.
+
 ## [1.0.1] - 2023-03-28
 
 ## [1.0.0] - 2023-02-15

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,12 +1,11 @@
 import { JanusClient } from '@vtex/api'
 
-export default class Catalog extends JanusClient {
+export default class CatalogClient extends JanusClient {
+  /**
+   * We use a high number as default to be sure to get all levels in category tree
+   * @see https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/catalog_system/pub/category/tree/-categoryLevels-
+   */
   public getCategoryTree = async (
-    /**
-     * We use a high number to be sure to get all levels in category tree
-     * @see https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/catalog_system/pub/category/tree/-categoryLevels-
-     */
-
     categoryLevels = 99
   ): Promise<CategoryTree> => {
     return this.http.get(

--- a/node/clients/categoriesMap.ts
+++ b/node/clients/categoriesMap.ts
@@ -1,9 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { InstanceOptions, IOContext, VBase } from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { VBase } from '@vtex/api'
 
 import { BUCKET, CATEGORIES_MAP } from '../contants'
 
-export default class CategoriesMap extends VBase {
+export default class CategoriesMapClient extends VBase {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
       ...options,

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,23 +1,28 @@
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { ClientsConfig, IOClients } from '@vtex/api'
+import type { ClientsConfig } from '@vtex/api'
+import { IOClients } from '@vtex/api'
 
-import Catalog from './catalog'
-import CategoriesMap from './categoriesMap'
-import Relevanc from './relevanc'
+import CatalogClient from './catalog'
+import CategoriesMapClient from './categoriesMap'
+import RelevancClient from './relevanc'
+import OffersMapClient from './offersMap'
 
 const MEDIUM_TIMEOUT_MS = 2 * 1000
 
 export class Clients extends IOClients {
   public get relevanc() {
-    return this.getOrSet('relevanc', Relevanc)
+    return this.getOrSet('relevanc', RelevancClient)
   }
 
   public get catalog() {
-    return this.getOrSet('catalog', Catalog)
+    return this.getOrSet('catalog', CatalogClient)
   }
 
   public get categoriesMap() {
-    return this.getOrSet('categoriesMap', CategoriesMap)
+    return this.getOrSet('categoriesMap', CategoriesMapClient)
+  }
+
+  public get offersMap() {
+    return this.getOrSet('offersMap', OffersMapClient)
   }
 }
 

--- a/node/clients/offersMap.ts
+++ b/node/clients/offersMap.ts
@@ -15,4 +15,6 @@ export default class OffersMapClient extends VBase {
 
   public updateOffersMap = (data: Relevanc.SponsoredOffersMap) =>
     this.saveJSON(BUCKET, OFFERS_MAP, data)
+
+  public clearOffersMap = () => this.saveJSON(BUCKET, OFFERS_MAP, null)
 }

--- a/node/clients/offersMap.ts
+++ b/node/clients/offersMap.ts
@@ -1,0 +1,18 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { VBase } from '@vtex/api'
+
+import { BUCKET, OFFERS_MAP } from '../contants'
+
+export default class OffersMapClient extends VBase {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+    })
+  }
+
+  public getOffersMap = (): Promise<Relevanc.SponsoredOffersMap | null> =>
+    this.getJSON(BUCKET, OFFERS_MAP, true)
+
+  public updateOffersMap = (data: Relevanc.SponsoredOffersMap) =>
+    this.saveJSON(BUCKET, OFFERS_MAP, data)
+}

--- a/node/clients/relevanC.ts
+++ b/node/clients/relevanC.ts
@@ -1,12 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import {
-  InstanceOptions,
-  IOContext,
-  ExternalClient,
-  PRODUCTION,
-} from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { ExternalClient, PRODUCTION } from '@vtex/api'
 
-export default class Relevanc extends ExternalClient {
+export default class RelevancClient extends ExternalClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super('https://ads.peps.relevanc.io', context, options)
   }

--- a/node/contants/index.ts
+++ b/node/contants/index.ts
@@ -4,6 +4,7 @@ export const PAGE_TYPE = {
 }
 
 export const CATEGORIES_MAP = 'categories-map'
+export const OFFERS_MAP = 'offers-map'
 export const ACCOUNT_BASE_URL = 'https://portal.vtexcommercestable.com.br/'
 export const BUCKET = 'relevanc'
 

--- a/node/resolvers/before.ts
+++ b/node/resolvers/before.ts
@@ -8,14 +8,6 @@ import {
 } from '../utils/resolvers'
 import { dynamicRulesMapper } from '../utils'
 
-/**
- * We use this object to store some information needed on the after resolver
- * In the future, the Intelligent Search Team might develop the feature to pass
- * information from the `before` to the `after` resolver.
- */
-// eslint-disable-next-line import/no-mutable-exports
-export const offersMap = {} as Relevanc.SponsoredOffersMap
-
 export async function before(
   _: unknown,
   args: SearchParams,
@@ -68,6 +60,8 @@ export async function before(
     return errorHandler('AdServer request failed', ctx)
   }
 
+  const offersMap = {} as Relevanc.SponsoredOffersMap
+
   offersMap.boostType = settings.boostType
 
   const dynamicRules = offers.map((offer) => {
@@ -75,6 +69,8 @@ export async function before(
 
     return dynamicRulesMapper(offer, settings)
   })
+
+  await ctx.clients.offersMap.updateOffersMap(offersMap)
 
   return { ...args, dynamicRules }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR implements VBase for the `offersMap` used in the before and after resolvers.
This was previously used with closures with a variable that was stored in memory.

#### What problem is this solving?
This could help prevent the issue of the rule filed in the `ProductContextProvider` not having the sponsored product tracking tag information.

#### How should this be manually tested?
The app is linked in the [workspace](https://relevancsponsor--exitocol.myvtex.com/admin/graphql-ide)
You can make this `query` in the GraphQL IDE using the `vtex.search-grapgql@0.51.0` app. You should get results with the sponsored products with the tracking tag information as you see in the image below.

```graphql
query {
  productSearch(fullText:"televisor") {
    products {
      productId
      productName
      description
      rule {
        id
      }
    }
  }
}
```

#### Screenshots
![Screenshot 2023-04-21 at 17 45 12](https://user-images.githubusercontent.com/17585823/233679156-57ea7629-66a9-467b-aeba-fa40e130c710.jpg)
